### PR TITLE
Change method copy_data to return a `Vec<u8>` instead of `String`

### DIFF
--- a/src/connection/_copy.rs
+++ b/src/connection/_copy.rs
@@ -61,9 +61,10 @@ impl Connection {
      * This method returns `Vec<u8>` since `libpq` can return binary data.
      * If you want a string, use [`String::from_utf8_lossy`].
      *
-     * [`String::from_utf8_lossy`]: https://doc.rust-lang.org/std/string/struct.String.html#method.from_utf8_lossy
      * See
      * [PQgetCopyData](https://www.postgresql.org/docs/current/libpq-copy.html#LIBPQ-PQGETCOPYDATA).
+     *
+     * [`String::from_utf8_lossy`]: https://doc.rust-lang.org/std/string/struct.String.html#method.from_utf8_lossy
      */
     pub fn copy_data(&self, r#async: bool) -> std::result::Result<Vec<u8>, String> {
         let mut ptr = std::ptr::null_mut();

--- a/src/connection/_copy.rs
+++ b/src/connection/_copy.rs
@@ -77,8 +77,7 @@ impl Connection {
             -1 => Err("COPY is done".to_string()),
             0 => Err("COPY still in progress".to_string()),
             nbytes => unsafe {
-                let buffer: Vec<u8> =
-                    std::slice::from_raw_parts(ptr as *const u8, nbytes as usize).to_vec();
+                let buffer = std::slice::from_raw_parts(ptr as *const u8, nbytes as usize).to_vec();
                 pq_sys::PQfreemem(ptr as *mut std::ffi::c_void);
                 Ok(buffer)
             },

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -467,37 +467,27 @@ mod test {
         let binary_data = {
             let header = {
                 let header_signature = b"PGCOPY\n\xFF\r\n\0";
-                // assert_eq!(header_signature.len(), 11);
                 let header_flags = b"\0\0\0\0";
-                // assert_eq!(header_flags.len(), 4);
                 let header_extension_length = b"\0\0\0\0";
-                // assert_eq!(header_extension_length.len(), 4);
 
-                let header = header_signature
+                header_signature
                     .iter()
                     .chain(header_flags.iter())
                     .chain(header_extension_length.iter())
                     .cloned()
-                    .collect::<Vec<u8>>();
-                // assert_eq!(header.len(), 11 + 4 + 4);
-                header
+                    .collect::<Vec<u8>>()
             };
             let tuples = {
                 let tuple_0_field_count = b"\x00\x01";
-                // assert_eq!(tuple_0_field_count.len(), 2);
                 let tuple_0_field_0_length = b"\x00\x00\x00\x07";
-                // assert_eq!(tuple_0_field_0_length.len(), 4);
                 let tuple_0_field_0_data = b"\xFF\x00\xFF\x00\xFF\x00\xFF";
-                // assert_eq!(tuple_0_field_0_data.len(), 7);
 
-                let tuple_0 = tuple_0_field_count
+                tuple_0_field_count
                     .iter()
                     .chain(tuple_0_field_0_length.iter())
                     .chain(tuple_0_field_0_data.iter())
                     .cloned()
-                    .collect::<Vec<u8>>();
-                // assert_eq!(tuple_0.len(), 2 + 4 + 7);
-                tuple_0
+                    .collect::<Vec<u8>>()
             };
             header
                 .iter()

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -457,7 +457,7 @@ mod test {
 
         let result = conn.exec("copy tmp to stdout");
         assert_eq!(result.status(), crate::Status::CopyOut);
-        assert_eq!(conn.copy_data(false).unwrap(), "1\n".to_string());
+        assert_eq!(conn.copy_data(false).unwrap(), b"1\n");
     }
 
     #[test]


### PR DESCRIPTION
This method could be util when someone is using `libpq-rs` to implement
a replication protocol consumer since it issues binary data that can contains many \0 bytes.