### PR TITLE
Improves error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --features v14
+          args: --all-features -- --deny warnings
 
   tests:
     name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,4 +125,4 @@ jobs:
       - name: build
         run: cargo test --no-run --features v14
       - name: valgrind
-        run: valgrind --leak-check=full --error-exitcode=1 $(find target/debug/deps -executable -type f)
+        run: valgrind --leak-check=full --error-exitcode=1 $(find target/debug/deps -executable -type f -name 'libpq-*')

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,6 @@ lint:clippy:
     script:
         - rustup component add clippy
         - cargo clippy --all-features -- --deny warnings
-    allow_failure: true
 
 test:
     <<: *pg

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,4 +61,4 @@ valgrind:
         PG: "14"
     script:
       - cargo test --no-run --features "v$PG"
-      - valgrind --leak-check=full --error-exitcode=1 $(find target/debug/deps -executable -type f)
+      - valgrind --leak-check=full --error-exitcode=1 $(find target/debug/deps -executable -type f -name 'libpq-*')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 [dependencies]
 libc = "0.2"
 log = "0.4"
+thiserror = "1.0"
 
 [dependencies.bitflags]
 version = "1.3"

--- a/src/connection/_async.rs
+++ b/src/connection/_async.rs
@@ -8,7 +8,7 @@ impl Connection {
      * See
      * [PQsendQuery](https://www.postgresql.org/docs/current/libpq-async.html#LIBPQ-PQSENDQUERY).
      */
-    pub fn send_query(&self, command: &str) -> std::result::Result<(), &str> {
+    pub fn send_query(&self, command: &str) -> crate::errors::Result {
         log::trace!("Sending query '{}'", command);
 
         let c_command = crate::ffi::to_cstr(command);
@@ -18,7 +18,7 @@ impl Connection {
         if success == 1 {
             Ok(())
         } else {
-            Err(self.error_message().unwrap_or("Unknow error"))
+            self.error()
         }
     }
 
@@ -35,7 +35,7 @@ impl Connection {
         param_values: &[Option<Vec<u8>>],
         param_formats: &[crate::Format],
         result_format: crate::Format,
-    ) -> std::result::Result<(), &str> {
+    ) -> crate::errors::Result {
         let (values, formats, lengths) = Self::transform_params(param_values, param_formats);
 
         Self::trace_query("Sending", command, param_types, param_values, param_formats);
@@ -70,7 +70,7 @@ impl Connection {
         if success == 1 {
             Ok(())
         } else {
-            Err(self.error_message().unwrap_or("Unknow error"))
+            self.error()
         }
     }
 
@@ -86,7 +86,7 @@ impl Connection {
         name: Option<&str>,
         query: &str,
         param_types: &[crate::Oid],
-    ) -> std::result::Result<(), &str> {
+    ) -> crate::errors::Result {
         let prefix = format!("Sending prepare {}", name.unwrap_or("anonymous"));
         Self::trace_query(&prefix, query, param_types, &[], &[]);
 
@@ -106,7 +106,7 @@ impl Connection {
         if success == 1 {
             Ok(())
         } else {
-            Err(self.error_message().unwrap_or("Unknow error"))
+            self.error()
         }
     }
 
@@ -121,7 +121,7 @@ impl Connection {
         param_values: &[Option<Vec<u8>>],
         param_formats: &[crate::Format],
         result_format: crate::Format,
-    ) -> std::result::Result<(), &str> {
+    ) -> crate::errors::Result {
         let prefix = format!("Send {} prepared query", name.unwrap_or("anonymous"));
         Self::trace_query(&prefix, "", &[], param_values, param_formats);
 
@@ -152,7 +152,7 @@ impl Connection {
         if success == 1 {
             Ok(())
         } else {
-            Err(self.error_message().unwrap_or("Unknow error"))
+            self.error()
         }
     }
 
@@ -161,7 +161,7 @@ impl Connection {
      *
      * See [PQsendDescribePortal](https://www.postgresql.org/docs/current/libpq-async.html#LIBPQ-PQSENDDESCRIBEPORTAL).
      */
-    pub fn send_describe_prepared(&self, name: Option<&str>) -> std::result::Result<(), &str> {
+    pub fn send_describe_prepared(&self, name: Option<&str>) -> crate::errors::Result {
         log::trace!(
             "Sending describe prepared query {}",
             name.unwrap_or("anonymous")
@@ -174,7 +174,7 @@ impl Connection {
         if success == 1 {
             Ok(())
         } else {
-            Err(self.error_message().unwrap_or("Unknow error"))
+            self.error()
         }
     }
 
@@ -184,7 +184,7 @@ impl Connection {
      * See
      * [PQsendDescribePortal](https://www.postgresql.org/docs/current/libpq-async.html#LIBPQ-PQSENDDESCRIBEPORTAL).
      */
-    pub fn send_describe_portal(&self, name: Option<&str>) -> std::result::Result<(), &str> {
+    pub fn send_describe_portal(&self, name: Option<&str>) -> crate::errors::Result {
         log::trace!("Sending describe portal {}", name.unwrap_or("anonymous"));
 
         let c_name = crate::ffi::to_cstr(name.unwrap_or_default());
@@ -194,7 +194,7 @@ impl Connection {
         if success == 1 {
             Ok(())
         } else {
-            Err(self.error_message().unwrap_or("Unknow error"))
+            self.error()
         }
     }
 
@@ -219,7 +219,7 @@ impl Connection {
      * See
      * [PQconsumeInput](https://www.postgresql.org/docs/current/libpq-async.html#LIBPQ-PQCONSUMEINPUT).
      */
-    pub fn consume_input(&self) -> std::result::Result<(), &str> {
+    pub fn consume_input(&self) -> crate::errors::Result {
         log::trace!("Consume input");
 
         let success = unsafe { pq_sys::PQconsumeInput(self.into()) };
@@ -227,7 +227,7 @@ impl Connection {
         if success == 1 {
             Ok(())
         } else {
-            Err(self.error_message().unwrap_or("Unknow error"))
+            self.error()
         }
     }
 
@@ -246,7 +246,7 @@ impl Connection {
      * See
      * [PQsetnonblocking](https://www.postgresql.org/docs/current/libpq-async.html#LIBPQ-PQSETNONBLOCKING).
      */
-    pub fn set_non_blocking(&self, non_blocking: bool) -> std::result::Result<(), ()> {
+    pub fn set_non_blocking(&self, non_blocking: bool) -> crate::errors::Result {
         if non_blocking {
             log::trace!("Set non blocking");
         } else {
@@ -256,7 +256,7 @@ impl Connection {
         let status = unsafe { pq_sys::PQsetnonblocking(self.into(), non_blocking as i32) };
 
         if status < 0 {
-            Err(())
+            Err(crate::errors::Error::Unknow)
         } else {
             Ok(())
         }
@@ -277,7 +277,7 @@ impl Connection {
      *
      * See [PQflush](https://www.postgresql.org/docs/current/libpq-async.html#LIBPQ-PQFLUSH).
      */
-    pub fn flush(&self) -> std::result::Result<(), ()> {
+    pub fn flush(&self) -> crate::errors::Result {
         log::trace!("Flush");
 
         let status = unsafe { pq_sys::PQflush(self.into()) };
@@ -285,7 +285,7 @@ impl Connection {
         if status == 0 {
             Ok(())
         } else {
-            Err(())
+            Err(crate::errors::Error::Unknow)
         }
     }
 }

--- a/src/connection/_copy.rs
+++ b/src/connection/_copy.rs
@@ -22,7 +22,7 @@ impl Connection {
 
         match success {
             -1 => self.error(),
-            0 => Err(crate::errors::Error::Misc("Full buffers".to_string())),
+            0 => Err(crate::errors::Error::Backend("Full buffers".to_string())),
             1 => Ok(()),
             _ => unreachable!(),
         }
@@ -48,7 +48,7 @@ impl Connection {
 
         match success {
             -1 => self.error(),
-            0 => Err(crate::errors::Error::Misc("Full buffers".to_string())),
+            0 => Err(crate::errors::Error::Backend("Full buffers".to_string())),
             1 => Ok(()),
             _ => unreachable!(),
         }
@@ -69,8 +69,8 @@ impl Connection {
 
         match success {
             -2 => self.error(),
-            -1 => Err(crate::errors::Error::Misc("COPY is done".to_string())),
-            0 => Err(crate::errors::Error::Misc("COPY still in progress".to_string())),
+            -1 => Err(crate::errors::Error::Backend("COPY is done".to_string())),
+            0 => Err(crate::errors::Error::Backend("COPY still in progress".to_string())),
             nbytes => Ok(PqBytes::from_raw(ptr as *const u8, nbytes as usize)),
         }
     }

--- a/src/connection/_copy.rs
+++ b/src/connection/_copy.rs
@@ -9,7 +9,7 @@ impl Connection {
      * See
      * [PQputCopyData](https://www.postgresql.org/docs/current/libpq-copy.html#LIBPQ-PQPUTCOPYDATA).
      */
-    pub fn put_copy_data(&self, buffer: &[u8]) -> std::result::Result<(), &str> {
+    pub fn put_copy_data(&self, buffer: &[u8]) -> crate::errors::Result {
         log::trace!("Sending copy data");
 
         let success = unsafe {
@@ -21,8 +21,8 @@ impl Connection {
         };
 
         match success {
-            -1 => Err(self.error_message().unwrap_or("Unknow error")),
-            0 => Err("Full buffers"),
+            -1 => self.error(),
+            0 => Err(crate::errors::Error::Misc("Full buffers".to_string())),
             1 => Ok(()),
             _ => unreachable!(),
         }
@@ -34,7 +34,7 @@ impl Connection {
      * See
      * [PQputCopyEnd](https://www.postgresql.org/docs/current/libpq-copy.html#LIBPQ-PQPUTCOPYEND).
      */
-    pub fn put_copy_end(&self, errormsg: Option<&str>) -> std::result::Result<(), &str> {
+    pub fn put_copy_end(&self, errormsg: Option<&str>) -> crate::errors::Result {
         log::trace!("End of copy");
 
         let cstr = errormsg.map(crate::ffi::to_cstr);
@@ -47,8 +47,8 @@ impl Connection {
         let success = unsafe { pq_sys::PQputCopyEnd(self.into(), ptr) };
 
         match success {
-            -1 => Err(self.error_message().unwrap_or("Unknow error")),
-            0 => Err("Full buffers"),
+            -1 => self.error(),
+            0 => Err(crate::errors::Error::Misc("Full buffers".to_string())),
             1 => Ok(()),
             _ => unreachable!(),
         }
@@ -62,15 +62,15 @@ impl Connection {
      * See
      * [PQgetCopyData](https://www.postgresql.org/docs/current/libpq-copy.html#LIBPQ-PQGETCOPYDATA)
      */
-    pub fn copy_data(&self, r#async: bool) -> std::result::Result<PqBytes, &str> {
+    pub fn copy_data(&self, r#async: bool) -> crate::errors::Result<PqBytes> {
         let mut ptr = std::ptr::null_mut();
 
         let success = unsafe { pq_sys::PQgetCopyData(self.into(), &mut ptr, r#async as i32) };
 
         match success {
-            -2 => Err(self.error_message().unwrap_or("Unknow error")),
-            -1 => Err("COPY is done"),
-            0 => Err("COPY still in progress"),
+            -2 => self.error(),
+            -1 => Err(crate::errors::Error::Misc("COPY is done".to_string())),
+            0 => Err(crate::errors::Error::Misc("COPY still in progress".to_string())),
             nbytes => Ok(PqBytes::from_raw(ptr as *const u8, nbytes as usize)),
         }
     }

--- a/src/connection/_exec.rs
+++ b/src/connection/_exec.rs
@@ -162,7 +162,7 @@ impl Connection {
      * See
      * [PQescapeLiteral](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQESCAPELITERAL).
      */
-    pub fn escape_literal(&self, str: &str) -> std::result::Result<PqString, &str> {
+    pub fn escape_literal(&self, str: &str) -> crate::errors::Result<PqString> {
         crate::escape::literal(self, str)
     }
 
@@ -174,7 +174,7 @@ impl Connection {
      * See
      * [PQescapeIdentifier](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQESCAPEIDENTIFIER).
      */
-    pub fn escape_identifier(&self, str: &str) -> std::result::Result<PqString, &str> {
+    pub fn escape_identifier(&self, str: &str) -> crate::errors::Result<PqString> {
         crate::escape::identifier(self, str)
     }
 
@@ -186,7 +186,7 @@ impl Connection {
      * See
      * [PQescapeStringConn](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQESCAPESTRINGCONN).
      */
-    pub fn escape_string(&self, from: &str) -> std::result::Result<PqString, &str> {
+    pub fn escape_string(&self, from: &str) -> crate::errors::Result<PqString> {
         crate::escape::string_conn(self, from)
     }
 
@@ -198,7 +198,7 @@ impl Connection {
      * See
      * [PQescapeByteaConn](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQESCAPEBYTEACONN).
      */
-    pub fn escape_bytea(&self, from: &[u8]) -> std::result::Result<PqBytes, &str> {
+    pub fn escape_bytea(&self, from: &[u8]) -> crate::errors::Result<PqBytes> {
         crate::escape::bytea_conn(self, from)
     }
 }

--- a/src/connection/_single_row_mode.rs
+++ b/src/connection/_single_row_mode.rs
@@ -8,7 +8,7 @@ impl Connection {
      * See
      * [PQsetSingleRowMode](https://www.postgresql.org/docs/current/libpq-single-row-mode.html#LIBPQ-PQSETSINGLEROWMODE).
      */
-    pub fn set_single_row_mode(&self) -> std::result::Result<(), ()> {
+    pub fn set_single_row_mode(&self) -> crate::errors::Result {
         log::trace!("Set single row mode");
 
         let success = unsafe { pq_sys::PQsetSingleRowMode(self.into()) };
@@ -16,7 +16,7 @@ impl Connection {
         if success == 1 {
             Ok(())
         } else {
-            Err(())
+            Err(crate::errors::Error::Unknow)
         }
     }
 }

--- a/src/connection/cancel.rs
+++ b/src/connection/cancel.rs
@@ -22,7 +22,7 @@ impl Cancel {
         if sucess == 1 {
             Ok(())
         } else {
-            Err(crate::errors::Error::Misc(error))
+            Err(crate::errors::Error::Backend(error))
         }
     }
 }

--- a/src/connection/cancel.rs
+++ b/src/connection/cancel.rs
@@ -9,7 +9,7 @@ impl Cancel {
      *
      * See [PQcancel](https://www.postgresql.org/docs/current/libpq-cancel.html#LIBPQ-PQCANCEL).
      */
-    pub fn request(&self) -> std::result::Result<(), String> {
+    pub fn request(&self) -> crate::errors::Result {
         log::trace!("Canceling");
 
         let capacity = 256;
@@ -17,12 +17,12 @@ impl Cancel {
         let ptr_error = c_error.into_raw();
 
         let sucess = unsafe { pq_sys::PQcancel(self.into(), ptr_error, capacity as i32) };
-        let error = crate::ffi::from_raw(ptr_error);
+        let error = crate::ffi::from_raw(ptr_error)?;
 
         if sucess == 1 {
             Ok(())
         } else {
-            Err(error)
+            Err(crate::errors::Error::Misc(error))
         }
     }
 }

--- a/src/connection/info.rs
+++ b/src/connection/info.rs
@@ -38,7 +38,7 @@ impl Info {
                 } else {
                     let err = crate::ffi::to_string(errmsg)?;
                     pq_sys::PQfreemem(errmsg as *mut std::ffi::c_void);
-                    return Err(crate::errors::Error::Misc(err));
+                    return Err(crate::errors::Error::Backend(err));
                 }
             }
 
@@ -127,7 +127,7 @@ mod test {
         assert!(crate::connection::Info::from("host=localhost user=postgres").is_ok());
         assert_eq!(
             crate::connection::Info::from("'"),
-            Err(crate::errors::Error::Misc(
+            Err(crate::errors::Error::Backend(
                 "missing \"=\" after \"'\" in connection info string\n".to_string()
             ))
         );

--- a/src/connection/info.rs
+++ b/src/connection/info.rs
@@ -25,7 +25,7 @@ impl Info {
      * See
      * [PQconninfoParse](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PQCONNINFOPARSE).
      */
-    pub fn from(dsn: &str) -> std::result::Result<Vec<Self>, String> {
+    pub fn from(dsn: &str) -> crate::errors::Result<Vec<Self>> {
         let c_dsn = crate::ffi::to_cstr(dsn);
 
         unsafe {
@@ -34,52 +34,54 @@ impl Info {
 
             if raw.is_null() {
                 if errmsg.is_null() {
-                    return Err("Unknow error".to_string());
+                    return Err(crate::errors::Error::Unknow);
                 } else {
-                    let err = crate::ffi::to_string(errmsg);
+                    let err = crate::ffi::to_string(errmsg)?;
                     pq_sys::PQfreemem(errmsg as *mut std::ffi::c_void);
-                    return Err(err);
+                    return Err(crate::errors::Error::Misc(err));
                 }
             }
 
             let info = Self::vec_from_nta(raw);
             pq_sys::PQconninfoFree(raw);
 
-            Ok(info)
+            info
         }
     }
 
-    fn from_raw(info: *mut pq_sys::_PQconninfoOption) -> Self {
-        unsafe {
+    fn from_raw(raw: *mut pq_sys::_PQconninfoOption) -> crate::errors::Result<Self> {
+        let info = unsafe {
             Self {
-                keyword: crate::ffi::to_string((*info).keyword),
-                envvar: if (*info).envvar.is_null() {
+                keyword: crate::ffi::to_string((*raw).keyword)?,
+                envvar: if (*raw).envvar.is_null() {
                     None
                 } else {
-                    Some(crate::ffi::to_string((*info).envvar))
+                    Some(crate::ffi::to_string((*raw).envvar)?)
                 },
-                compiled: if (*info).compiled.is_null() {
+                compiled: if (*raw).compiled.is_null() {
                     None
                 } else {
-                    Some(crate::ffi::to_string((*info).compiled))
+                    Some(crate::ffi::to_string((*raw).compiled)?)
                 },
-                val: if (*info).val.is_null() {
+                val: if (*raw).val.is_null() {
                     None
                 } else {
-                    Some(crate::ffi::to_string((*info).val))
+                    Some(crate::ffi::to_string((*raw).val)?)
                 },
-                label: if (*info).label.is_null() {
+                label: if (*raw).label.is_null() {
                     None
                 } else {
-                    Some(crate::ffi::to_string((*info).label))
+                    Some(crate::ffi::to_string((*raw).label)?)
                 },
-                dispchar: crate::ffi::to_string((*info).dispchar),
-                dispsize: (*info).dispsize,
+                dispchar: crate::ffi::to_string((*raw).dispchar)?,
+                dispsize: (*raw).dispsize,
             }
-        }
+        };
+
+        Ok(info)
     }
 
-    fn vec_from_nta(raw: *mut pq_sys::_PQconninfoOption) -> Vec<Self> {
+    fn vec_from_nta(raw: *mut pq_sys::_PQconninfoOption) -> crate::errors::Result<Vec<Self>> {
         let mut vec = Vec::new();
 
         for x in 0.. {
@@ -87,13 +89,13 @@ impl Info {
                 if (*raw.offset(x)).keyword.is_null() {
                     break;
                 } else {
-                    let info = raw.offset(x).into();
+                    let info = raw.offset(x).try_into()?;
                     vec.push(info);
                 }
             }
         }
 
-        vec
+        Ok(vec)
     }
 }
 
@@ -101,7 +103,7 @@ impl Default for Info {
     fn default() -> Self {
         unsafe {
             let raw = pq_sys::PQconndefaults();
-            let info = raw.into();
+            let info = raw.try_into().unwrap();
             pq_sys::PQconninfoFree(raw);
 
             info
@@ -110,8 +112,10 @@ impl Default for Info {
 }
 
 #[doc(hidden)]
-impl From<*mut pq_sys::_PQconninfoOption> for Info {
-    fn from(info: *mut pq_sys::_PQconninfoOption) -> Self {
+impl TryFrom<*mut pq_sys::_PQconninfoOption> for Info {
+    type Error = crate::errors::Error;
+
+    fn try_from(info: *mut pq_sys::_PQconninfoOption) -> Result<Self, Self::Error> {
         Self::from_raw(info)
     }
 }
@@ -123,7 +127,9 @@ mod test {
         assert!(crate::connection::Info::from("host=localhost user=postgres").is_ok());
         assert_eq!(
             crate::connection::Info::from("'"),
-            Err("missing \"=\" after \"'\" in connection info string\n".to_string())
+            Err(crate::errors::Error::Misc(
+                "missing \"=\" after \"'\" in connection info string\n".to_string()
+            ))
         );
     }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -153,7 +153,7 @@ impl Connection {
     pub(crate) fn error<T>(&self) -> crate::errors::Result<T> {
         Err(self
             .error_message()
-            .map(|x| crate::errors::Error::Misc(x.to_string()))
+            .map(|x| crate::errors::Error::Backend(x.to_string()))
             .unwrap_or(crate::errors::Error::Unknow))
     }
 }
@@ -412,7 +412,7 @@ mod test {
         let result = conn.send_prepare(None, "SELECT $1", &[crate::types::TEXT.oid]);
         assert_eq!(
             result,
-            Err(crate::errors::Error::Misc(
+            Err(crate::errors::Error::Backend(
                 "another command is already in progress\n".to_string()
             ))
         );
@@ -629,7 +629,7 @@ B	5	ReadyForQuery	 I
         assert_eq!(
             conn.encrypt_password("1234", "postgres", Some("test"))
                 .unwrap_err(),
-            crate::errors::Error::Misc(
+            crate::errors::Error::Backend(
                 "unrecognized password encryption algorithm \"test\"\n".to_string()
             ),
         );

--- a/src/connection/notify.rs
+++ b/src/connection/notify.rs
@@ -7,7 +7,7 @@ impl Notify {
     /**
      * notification channel name
      */
-    pub fn relname(&self) -> String {
+    pub fn relname(&self) -> crate::errors::Result<String> {
         crate::ffi::to_string(unsafe { (*self.notify).relname })
     }
 
@@ -21,7 +21,7 @@ impl Notify {
     /**
      * notification payload string
      */
-    pub fn extra(&self) -> String {
+    pub fn extra(&self) -> crate::errors::Result<String> {
         crate::ffi::to_string(unsafe { (*self.notify).extra })
     }
 }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -8,13 +8,15 @@ use crate::connection::PqString;
  * See [PQencryptPassword](https://www.postgresql.org/docs/current/libpq-misc.html#LIBPQ-PQENCRYPTPASSWORD).
  */
 #[deprecated(note = "Use libpq::Connection::encrypt_password instead")]
-pub fn password(passwd: &str, user: &str) -> PqString {
+pub fn password(passwd: &str, user: &str) -> crate::errors::Result<PqString> {
     let c_passwd = crate::ffi::to_cstr(passwd);
     let c_user = crate::ffi::to_cstr(user);
 
     unsafe {
         let ptr = pq_sys::PQencryptPassword(c_passwd.as_ptr(), c_user.as_ptr());
-        PqString::from_raw(ptr)
+        let encrypt = PqString::from_raw(ptr);
+
+        Ok(encrypt)
     }
 }
 
@@ -24,8 +26,8 @@ mod test {
     fn password() {
         #![allow(deprecated)]
         assert_eq!(
-            crate::encrypt::password("1234", "postgres").to_string_lossy(),
-            "md524bb002702969490e41e26e1a454036c"
+            crate::encrypt::password("1234", "postgres").map(|x| x.to_string_lossy().to_string()),
+            Ok("md524bb002702969490e41e26e1a454036c".to_string())
         );
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,17 @@
+use std::num::ParseIntError;
+
+pub type Result<T = ()> = std::result::Result<T, Error>;
+
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    ParseIntError(#[from] ParseIntError),
+    #[error("{0}")]
+    NulError(#[from] std::ffi::NulError),
+    #[error("{0}")]
+    Misc(String),
+    #[error("Unknow error")]
+    Unknow,
+    #[error("{0}")]
+    Utf8(#[from] std::str::Utf8Error),
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,7 @@ pub enum Error {
     #[error("{0}")]
     NulError(#[from] std::ffi::NulError),
     #[error("{0}")]
-    Misc(String),
+    Backend(String),
     #[error("Unknow error")]
     Unknow,
     #[error("{0}")]

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -107,7 +107,7 @@ pub fn bytea(from: &[u8]) -> crate::errors::Result<PqBytes> {
             /* According to libpq docs (v14): `Currently, the only possible error is insufficient memory`
              * This was also confirmed by looking at the source code of PQescapeBytea.
              */
-            Err(crate::errors::Error::Misc("out of memory\n".to_string()))
+            Err(crate::errors::Error::Backend("out of memory\n".to_string()))
         } else {
             Ok(PqBytes::from_raw(to_ptr, to_len as usize))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 #![warn(warnings)]
-#![allow(clippy::result_unit_err)]
+#![allow(clippy::missing_safety_doc)]
 
 #[macro_use]
 mod ffi;
 
 pub mod connection;
 pub mod encrypt;
+pub mod errors;
 pub mod escape;
 pub mod ping;
 pub mod poll;

--- a/src/result/attribute.rs
+++ b/src/result/attribute.rs
@@ -10,11 +10,13 @@ pub struct Attribute {
 }
 
 #[doc(hidden)]
-impl From<&&Attribute> for pq_sys::pgresAttDesc {
-    fn from(attribute: &&Attribute) -> pq_sys::pgresAttDesc {
-        let name = std::ffi::CString::new(attribute.name.clone()).unwrap();
+impl TryFrom<&&Attribute> for pq_sys::pgresAttDesc {
+    type Error = crate::errors::Error;
 
-        pq_sys::pgresAttDesc {
+    fn try_from(attribute: &&Attribute) -> Result<Self, Self::Error> {
+        let name = std::ffi::CString::new(attribute.name.clone())?;
+
+        Ok(pq_sys::pgresAttDesc {
             name: name.into_raw(),
             tableid: attribute.tableid,
             columnid: attribute.columnid,
@@ -22,6 +24,6 @@ impl From<&&Attribute> for pq_sys::pgresAttDesc {
             typid: attribute.typid,
             typlen: attribute.typlen,
             atttypmod: attribute.atttypmod,
-        }
+        })
     }
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -93,6 +93,10 @@ impl From<&Status> for pq_sys::ExecStatusType {
 
 impl ToString for Status {
     fn to_string(&self) -> String {
-        crate::ffi::to_string(unsafe { pq_sys::PQresStatus(self.into()) })
+        let status = unsafe { pq_sys::PQresStatus(self.into()) };
+
+        crate::connection::PqString::from_raw(status)
+            .to_string_lossy()
+            .to_string()
     }
 }


### PR DESCRIPTION
This is last modifications I would like to do before the 3.0 release.

@iuridiniz I don’t think it’s possible to avoid the String conversion for error messages.