### PR TITLE
fix broken repository link (fixes #17)

### DIFF
--- a/libpq-sys/Cargo.toml
+++ b/libpq-sys/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.0"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>", "Sanpi <sanpi@homecomputing.fr"]
 description = "Auto-generated rust bindings for libpq"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/sanpii/libpq"
+repository = "https://github.com/sanpii/libpq.rs"
 links = "pq"
 edition = "2021"
 


### PR DESCRIPTION
This just fixes the link that shows up in crates.io.