### PR TITLE
feat: rename crate::Result to PQResult

### DIFF
--- a/src/connection/_async.rs
+++ b/src/connection/_async.rs
@@ -203,7 +203,7 @@ impl Connection {
      *
      * See [PQgetResult](https://www.postgresql.org/docs/current/libpq-async.html#LIBPQ-PQGETRESULT).
      */
-    pub fn result(&self) -> Option<crate::Result> {
+    pub fn result(&self) -> Option<crate::PQResult> {
         let raw = unsafe { pq_sys::PQgetResult(self.into()) };
 
         if raw.is_null() {

--- a/src/connection/_exec.rs
+++ b/src/connection/_exec.rs
@@ -7,7 +7,7 @@ impl Connection {
      *
      * See [PQexec](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQEXEC).
      */
-    pub fn exec(&self, query: &str) -> crate::Result {
+    pub fn exec(&self, query: &str) -> crate::PQResult {
         log::trace!("Execute query '{}'", query);
 
         let c_query = crate::ffi::to_cstr(query);
@@ -27,7 +27,7 @@ impl Connection {
         param_values: &[Option<Vec<u8>>],
         param_formats: &[crate::Format],
         result_format: crate::Format,
-    ) -> crate::Result {
+    ) -> crate::PQResult {
         let (values, formats, lengths) = Self::transform_params(param_values, param_formats);
 
         Self::trace_query("Sending", command, param_types, param_values, param_formats);
@@ -71,7 +71,7 @@ impl Connection {
         name: Option<&str>,
         query: &str,
         param_types: &[crate::Oid],
-    ) -> crate::Result {
+    ) -> crate::PQResult {
         let prefix = format!("Prepare {}", name.unwrap_or("anonymous"));
         Self::trace_query(&prefix, query, param_types, &[], &[]);
 
@@ -102,7 +102,7 @@ impl Connection {
         param_values: &[Option<Vec<u8>>],
         param_formats: &[crate::Format],
         result_format: crate::Format,
-    ) -> crate::Result {
+    ) -> crate::PQResult {
         let prefix = format!("Execute {} prepared query", name.unwrap_or("anonymous"));
         Self::trace_query(&prefix, "", &[], param_values, param_formats);
 
@@ -138,7 +138,7 @@ impl Connection {
      *
      * See [PQdescribePrepared](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQDESCRIBEPREPARED).
      */
-    pub fn describe_prepared(&self, name: Option<&str>) -> crate::Result {
+    pub fn describe_prepared(&self, name: Option<&str>) -> crate::PQResult {
         let c_name = crate::ffi::to_cstr(name.unwrap_or_default());
 
         unsafe { pq_sys::PQdescribePrepared(self.into(), c_name.as_ptr()) }.into()
@@ -149,7 +149,7 @@ impl Connection {
      *
      * See [PQdescribePortal](https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQDESCRIBEPORTAL).
      */
-    pub fn describe_portal(&self, name: Option<&str>) -> crate::Result {
+    pub fn describe_portal(&self, name: Option<&str>) -> crate::PQResult {
         let c_name = crate::ffi::to_cstr(name.unwrap_or_default());
 
         unsafe { pq_sys::PQdescribePortal(self.into(), c_name.as_ptr()) }.into()

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -237,7 +237,7 @@ mod test {
         assert!(crate::Connection::is_thread_safe());
 
         let thread = std::thread::spawn(move || {
-            assert_eq!(conn.exec("SELECT 1").status(), crate::Status::TupplesOk)
+            assert_eq!(conn.exec("SELECT 1").status(), crate::Status::TuplesOk)
         });
 
         thread.join().ok();
@@ -262,7 +262,7 @@ mod test {
     fn exec() {
         let conn = crate::test::new_conn();
         let results = conn.exec("SELECT 1 as one, 2 as two from generate_series(1,2)");
-        assert_eq!(results.status(), crate::Status::TupplesOk);
+        assert_eq!(results.status(), crate::Status::TuplesOk);
         assert_eq!(results.ntuples(), 2);
         assert_eq!(results.nfields(), 2);
 
@@ -288,7 +288,7 @@ mod test {
             &[],
             crate::Format::Text,
         );
-        assert_eq!(results.status(), crate::Status::TupplesOk);
+        assert_eq!(results.status(), crate::Status::TuplesOk);
 
         assert_eq!(results.value(0, 0), Some(&b"1"[..]));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use connection::Connection;
 pub use encoding::*;
 pub use format::*;
 pub use oid::*;
-pub use result::Result;
+pub use result::PQResult;
 pub use state::State;
 pub use status::*;
 pub use types::Type;

--- a/src/result/mod.rs
+++ b/src/result/mod.rs
@@ -5,11 +5,11 @@ pub use attribute::*;
 pub use error_field::*;
 
 #[derive(Clone)]
-pub struct Result {
+pub struct PQResult {
     result: *mut pq_sys::PGresult,
 }
 
-impl Result {
+impl PQResult {
     /**
      * Constructs an empty `Result` object with the given status.
      *
@@ -472,45 +472,45 @@ impl Result {
     }
 }
 
-unsafe impl Send for Result {}
+unsafe impl Send for PQResult {}
 
-unsafe impl Sync for Result {}
+unsafe impl Sync for PQResult {}
 
-impl Drop for Result {
+impl Drop for PQResult {
     fn drop(&mut self) {
         unsafe { pq_sys::PQclear(self.into()) };
     }
 }
 
 #[doc(hidden)]
-impl From<*mut pq_sys::PGresult> for Result {
+impl From<*mut pq_sys::PGresult> for PQResult {
     fn from(result: *mut pq_sys::PGresult) -> Self {
-        Result { result }
+        PQResult { result }
     }
 }
 
 #[doc(hidden)]
-impl From<&Result> for *mut pq_sys::PGresult {
-    fn from(result: &Result) -> *mut pq_sys::PGresult {
+impl From<&PQResult> for *mut pq_sys::PGresult {
+    fn from(result: &PQResult) -> *mut pq_sys::PGresult {
         result.result
     }
 }
 
 #[doc(hidden)]
-impl From<&mut Result> for *mut pq_sys::PGresult {
-    fn from(result: &mut Result) -> *mut pq_sys::PGresult {
+impl From<&mut PQResult> for *mut pq_sys::PGresult {
+    fn from(result: &mut PQResult) -> *mut pq_sys::PGresult {
         result.result
     }
 }
 
 #[doc(hidden)]
-impl From<&Result> for *const pq_sys::PGresult {
-    fn from(result: &Result) -> *const pq_sys::PGresult {
+impl From<&PQResult> for *const pq_sys::PGresult {
+    fn from(result: &PQResult) -> *const pq_sys::PGresult {
         result.result
     }
 }
 
-impl std::fmt::Debug for Result {
+impl std::fmt::Debug for PQResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Result")
             .field("inner", &self.result)

--- a/src/status.rs
+++ b/src/status.rs
@@ -20,12 +20,12 @@ pub enum Status {
     /** A nonfatal error (a notice or warning) occurred. */
     NonFatalError,
     /**
-     * The `libpq::Result` contains a single result tuple from the current command. This status
+     * The `libpq::PQResult` contains a single result tuple from the current command. This status
      * occurs only when single-row mode has been selected for the query
      */
-    SingleTuble,
+    SingleTuple,
     /** Successful completion of a command returning data (such as a `SELECT` or `SHOW`). */
-    TupplesOk,
+    TuplesOk,
 
     /** Pipeline synchronization point. */
     #[cfg(feature = "v14")]
@@ -48,8 +48,8 @@ impl From<pq_sys::ExecStatusType> for Status {
             pq_sys::ExecStatusType::PGRES_EMPTY_QUERY => Self::EmptyQuery,
             pq_sys::ExecStatusType::PGRES_FATAL_ERROR => Self::FatalError,
             pq_sys::ExecStatusType::PGRES_NONFATAL_ERROR => Self::NonFatalError,
-            pq_sys::ExecStatusType::PGRES_SINGLE_TUPLE => Self::SingleTuble,
-            pq_sys::ExecStatusType::PGRES_TUPLES_OK => Self::TupplesOk,
+            pq_sys::ExecStatusType::PGRES_SINGLE_TUPLE => Self::SingleTuple,
+            pq_sys::ExecStatusType::PGRES_TUPLES_OK => Self::TuplesOk,
             #[cfg(feature = "v14")]
             pq_sys::ExecStatusType::PGRES_PIPELINE_SYNC => Self::PipelineSync,
             #[cfg(feature = "v14")]
@@ -79,8 +79,8 @@ impl From<&Status> for pq_sys::ExecStatusType {
             Status::EmptyQuery => pq_sys::ExecStatusType::PGRES_EMPTY_QUERY,
             Status::FatalError => pq_sys::ExecStatusType::PGRES_FATAL_ERROR,
             Status::NonFatalError => pq_sys::ExecStatusType::PGRES_NONFATAL_ERROR,
-            Status::SingleTuble => pq_sys::ExecStatusType::PGRES_SINGLE_TUPLE,
-            Status::TupplesOk => pq_sys::ExecStatusType::PGRES_TUPLES_OK,
+            Status::SingleTuple => pq_sys::ExecStatusType::PGRES_SINGLE_TUPLE,
+            Status::TuplesOk => pq_sys::ExecStatusType::PGRES_TUPLES_OK,
             #[cfg(feature = "v14")]
             Status::PipelineSync => pq_sys::ExecStatusType::PGRES_PIPELINE_SYNC,
             #[cfg(feature = "v14")]


### PR DESCRIPTION
Fixes #42 

Rename `crate::Result` to `crate::PQResult` to distinguish it from `crate::errors::Result`.
